### PR TITLE
Update parser.py

### DIFF
--- a/DSSPparser/parser.py
+++ b/DSSPparser/parser.py
@@ -48,7 +48,7 @@ class parseDSSP(object):
         input_handle = open(self._file, 'r')
         flag = False
         for line in input_handle:
-            if (re.search('#', line)):
+            if line.split()[0] == '#':
                 flag = True
                 continue
             if flag:


### PR DESCRIPTION
Changed line 51.

Previous code incorrectly parses a file if the '#' symbol is used in the header.

The new code correctly identifies the start of the table by noting the '#' symbol in between whitespace. This will break if a header either contains an empty line (because split() will return an empty list) or if the header contains a line that starts with ' # '.

I ran the code on the entire DSSP database, and I have not yet found any problems.